### PR TITLE
Changed include and namespace of unordered_map in minerCap.h

### DIFF
--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -20,7 +20,7 @@ You will need Apple's **XCode** (Command Line Tools are not sufficient). For Mac
   
   ```git checkout beta-1.0.0```
   
-  ```./autogen.sh && ./configure```
+  ```./autogen.sh && export CXXFLAGS=-std=c++11 && ./configure```
   
   ```make && make deploy```
 

--- a/src/minerCap.h
+++ b/src/minerCap.h
@@ -10,11 +10,11 @@
 
 #include "pubkey.h"
 #include <boost/filesystem/path.hpp>
-#include <tr1/unordered_map>
+#include <unordered_map>
 
 class CMinerCap {
 private:
-	typedef std::tr1::unordered_map <std::string, uint32_t> minerCapMap;
+	typedef std::unordered_map <std::string, uint32_t> minerCapMap;
 public:
 	CMinerCap();
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -21,7 +21,7 @@
 #include "utilstrencodings.h"
 #include "hash.h"
 
-#include <tr1/unordered_map>
+#include <unordered_map>
 #include "base58.h"
 
 #include <stdint.h>
@@ -654,7 +654,7 @@ UniValue dumpminerstats(const UniValue& params, bool fHelp){
 		minerParamater = params[0].getValStr();
 
 	UniValue result(UniValue::VOBJ);
-	typedef std::tr1::unordered_map <std::string, uint32_t> minerCapMap;
+	typedef std::unordered_map <std::string, uint32_t> minerCapMap;
 
 	CMinerCap minerCap;
 	minerCapMap minerMap;


### PR DESCRIPTION
Apparently, unordered_map is included in C++11 and some compilers (namely LLVM v8.0 in my case) no longer support including with `<tr1/unordered_map>` but use `<unordered_map>`. Because of this, IoP does not compile under OS X. If the old way is still needed for backwards compatibility, could someone write a routine that checks for the OS? Also, I explicitly added the c++11 option to the build instructions for macOS.