### PR TITLE
Update OSX Guide

### DIFF
--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -62,7 +62,7 @@ If everything goes well, you can find the disk image `IoP Core.dmg` in your Docu
 
 - Run `./configure`
 
-- Run `make && make deploy`. You might get some warnings about deprecated functions. Ignore them. If everything goes well, you can find the disk image `IoP Core.dmg` in `~/GitHub/iop-token`. Drag this to your Applications Folder.
+- Run `make && make deploy`. You might get some warnings about deprecated functions. Ignore them. If everything goes well, you can find the disk image `IoP Core.dmg` in `~/GitHub/iop-token`. Mount it by double-clicking and drag the Application `IoP Core` onto your Applications Folder.
 
 ## Some Notes
 

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -54,6 +54,8 @@ If everything goes well, you can find the disk image `IoP Core.dmg` in your Docu
 
 - Change to this location using `cd ~/GitHub/iop-token` or equivalent.
 
+- Make sure you are on the `beta` branch: `git checkout beta`
+
 - Run `./autogen.sh`
 
 - Add compiler flags via `export CXXFLAGS=-std=c++11`

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -3,6 +3,7 @@ At the moment we only provide instructions to build your own copy of IoP Core. I
 You will need Apple's **XCode** (Command Line Tools are not sufficient). For Mac OS X 10.11.5 or higher, it is provided for free via the Mac App Store. If you are on a lower Version of Mac OS X, you need to manually download Xcode from the developer homepage. For this you need to register for a free Apple developer account on <http://developer.apple.com>
 
 # Building IoP Core on Mac OS X for Laymen
+- This guide is made for people who have no experience building their own software. As the IoP wallet software is still under heavy development, difficulties may arise. Please report all issues and be patient for an actual release or an updated guide.
 
 - Update you Mac to the newest version available (at least 10.11.5)
 - Install the latest XCode Package from the Mac App Store and run it. Accept the License Agreement and let it install components. 
@@ -14,17 +15,17 @@ You will need Apple's **XCode** (Command Line Tools are not sufficient). For Mac
   ```brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 libevent qt5```
   This will take a while.
   
-  ```git clone https://github.com/Fermat-ORG/iop-blockchain.git ~/Documents/iop-blockchain```
+  ```git clone https://github.com/Fermat-ORG/iop-token.git ~/Documents/iop-token```
   
-  ```cd ~/Documents/iop-blockchain```
+  ```cd ~/Documents/iop-token```
   
-  ```git checkout beta-1.0.0```
+  ```git checkout beta```
   
   ```./autogen.sh && export CXXFLAGS=-std=c++11 && ./configure```
   
   ```make && make deploy```
 
-If everything goes well, you can find the application `IoP Core.app` in your Documents Folder under iop-blockchain. Drag this to your Applications Folder.
+If everything goes well, you can find the disk image `IoP Core.dmg` in your Documents Folder under iop-token. Mount it by double-clicking and drag the Application `IoP Core` onto your Applications Folder.
 
 # Building IoP Core on Mac OS X 
 
@@ -48,16 +49,18 @@ If everything goes well, you can find the application `IoP Core.app` in your Doc
 - Use the terminal to clone the git repository to your favorite location with e.g.
 
   ```
-  git clone https://github.com/Fermat-ORG/iop-blockchain.git ~/GitHub/iop-blockchain
+  git clone https://github.com/Fermat-ORG/iop-token.git ~/GitHub/iop-token
   ```
 
-- Change to this location using `cd ~/GitHub/iop-blockchain` or equivalent.
+- Change to this location using `cd ~/GitHub/iop-token` or equivalent.
 
 - Run `./autogen.sh`
 
+- Add compiler flags via `export CXXFLAGS=-std=c++11`
+
 - Run `./configure`
 
-- Run `make && make deploy`. You might get some warnings about deprecated functions. Ignore them. If everything goes well, you can find the application `IoP Core.app` in `~/GitHub/iop-blockchain`. Drag this to your Applications Folder.
+- Run `make && make deploy`. You might get some warnings about deprecated functions. Ignore them. If everything goes well, you can find the disk image `IoP Core.dmg` in `~/GitHub/iop-token`. Drag this to your Applications Folder.
 
 ## Some Notes
 


### PR DESCRIPTION
I updated the information in the guide to reflect the change of branch and some additional necessary build flags.

The link on the fermat.org website still points to the beta-1.0.0 version of the guide. Could someone change that?