### PR TITLE
Warning instead of error if whitelist address parameter is missing

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1500,7 +1500,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         // Changed option name
         string whitelistAddressStr = GetArg("-minewhitelistaddr", "");
         if ( whitelistAddressStr.empty() ) {
-            return InitError("Mining was enabled but whitelisted miner address is not specified");
+            // NOTE whitelisting may not be currently active, so give just a warning here instead of an error
+            InitWarning("Mining is enabled but whitelisted miner address is not specified.");
         }
         
         // minerWhiteListAddress must be a valid address on this network.


### PR DESCRIPTION
Raising an error makes no sense if whitelisting is not active, but I think it worths at least a warning as whitelisting may be activated later.

Unfortunately it might need more work to make this right: as far as I understand, somehow the miner should also detect if whitelisting was enabled/disabled and change block signing behaviour accordingly. Currently the miner just checks minerCap limits but not whitelisting.