### PR TITLE
Mining fix

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1576,7 +1576,7 @@ void MinerThread( boost::shared_ptr<CReserveScript> coinbaseScript,
             /* before we start mining, let's make sure we withing the cap if the Miner Cap is enabled */
             CMinerCap minerCap;
             if (minerCap.isEnabled()){
-                while (isMinerCapReached(whitelistAddress)){
+                while (isMinerCapReached(whitelistAddress.ToString())){
                     LogPrintf("Miner cap reached. Waiting a minute to retry...\n");
                     MilliSleep(1000 * 60);
                 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -78,7 +78,7 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript,
 
 #include "base58.h" // To access class CIoPAddress to handle the mining target address parameter
 void MinerThread(boost::shared_ptr<CReserveScript> coinbaseScript,
-    const string &whitelistAddress, const CIoPAddress &minerAddress);
+    const CIoPAddress &whitelistAddress);
 
 
 
@@ -1532,7 +1532,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             boost::shared_ptr<CReserveScript> coinbaseScript( new CReserveScript() );
             coinbaseScript->reserveScript = GetScriptForDestination( mineToAddress.Get() );
             
-            threadGroup.create_thread(boost::bind(&MinerThread, coinbaseScript, whitelistAddressStr, mineToAddress));
+            threadGroup.create_thread(boost::bind(&MinerThread, coinbaseScript, whitelistAddress));
         }
     }
 #endif
@@ -1541,7 +1541,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 }
 
 void MinerThread( boost::shared_ptr<CReserveScript> coinbaseScript,
-                  const string &whitelistAddress, const CIoPAddress &minerAddress )
+                  const CIoPAddress &whitelistAddress )
 {
     // we must wait for the wallet to be unlocked in order to get the private key
     while (IsWalletLocked()) {
@@ -1552,14 +1552,14 @@ void MinerThread( boost::shared_ptr<CReserveScript> coinbaseScript,
     }
 
     CKeyID keyID;
-    if (!minerAddress.GetKeyID(keyID)){
+    if (!whitelistAddress.GetKeyID(keyID)){
         LogPrintf("Provided minerWhiteListAddress does not refer to a key.\n");
         return;
     }
 
     CKey vchSecret;
     if (!pwalletMain->GetKey(keyID, vchSecret)){
-        LogPrintf("Private key for %s is not known.\n", whitelistAddress.c_str());
+        LogPrintf("Private key for %s is not known.\n", whitelistAddress.ToString());
         return;
     }
 


### PR DESCRIPTION
Fixed an error that caused the mining to fail when not mining to own wallet.

The program was looking for the private Key of the `mineto` Address instead of the `minewhitelistaddr`. 
This made mining fail immediately when mining to an address that is not in own wallet.

It should also lead to rejection of blocks because the signing is done with the wrong private key.
Was the whitelist disabled in testnet recently? That would explain why I couldn't mine on testnet with the new version a few days ago but can do so now.